### PR TITLE
Fast track msm

### DIFF
--- a/citations.bib
+++ b/citations.bib
@@ -1,0 +1,27 @@
+@Misc{numpy,
+  author =    {Travis Oliphant},
+  title =     {{NumPy}: A guide to {NumPy}},
+  year =      {2006--},
+  howpublished = {USA: Trelgol Publishing},
+  url = "http://www.numpy.org/",
+  note = {[Online; accessed <today>]}
+ }
+
+@InProceedings{SciPyProceedings_11,
+  author =       {Aric A. Hagberg and Daniel A. Schult and Pieter J. Swart},
+  title =        {Exploring Network Structure, Dynamics, and Function using NetworkX},
+  booktitle =   {Proceedings of the 7th Python in Science Conference},
+  pages =     {11 - 15},
+  address = {Pasadena, CA USA},
+  year =      {2008},
+  editor =    {Ga\"el Varoquaux and Travis Vaught and Jarrod Millman},
+}
+
+@book{10.5555/1593511,
+ author = {Van Rossum, Guido and Drake, Fred L.},
+ title = {Python 3 Reference Manual},
+ year = {2009},
+ isbn = {1441412697},
+ publisher = {CreateSpace},
+ address = {Scotts Valley, CA}
+}

--- a/settings/atlanta/demographics.yml
+++ b/settings/atlanta/demographics.yml
@@ -31,7 +31,9 @@ demographics:
         init: 0.232
       haart:
         init: 0.625
-        prob: 0.35
+        start_haart:
+          1:
+            prob: 0.35
         adherence: 0.885
         discontinue: 0.10
       safe_sex: 0.688
@@ -69,7 +71,9 @@ demographics:
         init: 0.07
       haart:
         init: 0.585
-        prob: 0.20
+        start_haart:
+          1:
+            prob: 0.20
         adherence: 0.817
         discontinue: 0.07
       safe_sex: 0.528

--- a/settings/nyc_msm/demograpics.yml
+++ b/settings/nyc_msm/demograpics.yml
@@ -27,6 +27,9 @@ demographics:
           third_dx_period:
             start_time: 4
             prob: 0.49
+        reinit_prob: 0.041
+        adherence: 0.6794
+        discontinue: 0.0059
   black:
     ppl: 0.3
     MSM:

--- a/settings/nyc_msm/demograpics.yml
+++ b/settings/nyc_msm/demograpics.yml
@@ -4,9 +4,10 @@ demographics:
     MSM:
       ppl: 1.0
       sex_role:
-        insertive: 0.439
-        receptive: 0.286
-        versatile: 0.276
+        init:
+          insertive: 0.439
+          receptive: 0.286
+          versatile: 0.276
       hiv:
         init: 0.111
         dx:
@@ -16,6 +17,22 @@ demographics:
         init: 0.471
       haart:
         init: 0.7912
-        prob:
-
+        start_haart:
+          recent_diagnosis:
+            start_time: 1
+            prob: 0.742
+          second_dx_period:
+            start_time: 2
+            prob: 0.163
+          third_dx_period:
+            start_time: 4
+            prob: 0.49
+  black:
+    ppl: 0.3
+    MSM:
+      ppl: 1.0
+  latino:
+    ppl: 0.2
+    MSM:
+      ppl: 1.0
 

--- a/settings/nyc_msm/demograpics.yml
+++ b/settings/nyc_msm/demograpics.yml
@@ -1,0 +1,21 @@
+demographics:
+  white:
+    ppl: 0.500
+    MSM:
+      ppl: 1.0
+      sex_role:
+        insertive: 0.439
+        receptive: 0.286
+        versatile: 0.276
+      hiv:
+        init: 0.111
+        dx:
+          init: 0.920
+          prob: 0.184
+      aids:
+        init: 0.471
+      haart:
+        init: 0.7912
+        prob:
+
+

--- a/settings/nyc_msm/model.yml
+++ b/settings/nyc_msm/model.yml
@@ -13,7 +13,10 @@ classes:
       sleeps_with:
         - MSM
   bond_types:
-    Sex:
+    sex_main:
+      acts_allowed:
+        - sex
+    sex_casual:
       acts_allowed:
         - sex
   drug_types:
@@ -42,3 +45,9 @@ assort_mix:
       white: 0.313
       black: 0.227
       latino: 0.460
+
+partnership:
+  duration:
+    sex_main:
+
+    sex_casual:

--- a/settings/nyc_msm/model.yml
+++ b/settings/nyc_msm/model.yml
@@ -1,0 +1,44 @@
+classes:
+  races:
+    white:
+      hispanic: false
+    black:
+      hispanic: false
+    latino:
+      hispanic: true
+  sex_types:
+    MSM:
+      gender: M
+      cis_trans: cis
+      sleeps_with:
+        - MSM
+  bond_types:
+    Sex:
+      acts_allowed:
+        - sex
+  drug_types:
+    - None
+  populations: []
+
+assort_mix:
+  assort_white:
+    attribute: race
+    agent_value: white
+    partner_values:
+      white: 0.649
+      black: 0.099
+      latino: 0.252
+  assort_black:
+    attribute: race
+    agent_value: black
+    partner_values:
+      white: 0.185
+      black: 0.560
+      latino: 0.227
+  assort_latino:
+    attribute: race
+    agent_value: latino
+    partner_values:
+      white: 0.313
+      black: 0.227
+      latino: 0.460

--- a/settings/scott/demographics.yml
+++ b/settings/scott/demographics.yml
@@ -38,7 +38,9 @@ demographics:
           prob: 0.202
       haart:
         init: 1.0
-        prob: 0.679
+        start_haart:
+          1:
+            prob: 0.679
         adherence: 1.0
         discontinue: 0.000
       injection:
@@ -104,7 +106,9 @@ demographics:
           prob: 0.2
       haart:
         init: 1.0
-        prob: 0.679
+        start_haart:
+          1:
+            prob: 0.679
         adherence: 1.0
         discontinue: 0.000
       injection:
@@ -164,7 +168,9 @@ demographics:
           init: 1.0
       haart:
         init: 1.0
-        prob: 0.679
+        start_haart:
+          1:
+            prob: 0.679
         adherence: 1.0
         discontinue: 0.000
       injection:

--- a/tests/params/basic.yml
+++ b/tests/params/basic.yml
@@ -44,7 +44,9 @@ demographics:
         init: 0.1
       haart:
         init: 0.1
-        prob: 0.1
+        start_haart:
+          1:
+            prob: 0.1
         adherence: 0.1
         discontinue: 0.1
       incar:
@@ -108,7 +110,9 @@ demographics:
         init: 0.1
       haart:
         init: 0.1
-        prob: 0.1
+        start_haart:
+          1:
+            prob: 0.1
         adherence: 0.1
         discontinue: 0.1
       incar:
@@ -172,7 +176,9 @@ demographics:
         init: 0.1
       haart:
         init: 0.1
-        prob: 0.1
+        start_haart:
+          1:
+            prob: 0.1
         adherence: 0.1
         discontinue: 0.1
       incar:
@@ -236,7 +242,9 @@ demographics:
         init: 0.1
       haart:
         init: 0.1
-        prob: 0.1
+        start_haart:
+          1:
+            prob: 0.1
         adherence: 0.1
         discontinue: 0.1
       incar:
@@ -300,7 +308,9 @@ demographics:
         init: 0.1
       haart:
         init: 0.1
-        prob: 0.1
+        start_haart:
+          1:
+            prob: 0.1
         adherence: 0.1
         discontinue: 0.1
       incar:
@@ -357,7 +367,9 @@ demographics:
         init: 0.1
       haart:
         init: 0.1
-        prob: 0.1
+        start_haart:
+          1:
+            prob: 0.1
         adherence: 0.1
         discontinue: 0.1
       incar:
@@ -430,7 +442,9 @@ demographics:
         init: 0.1
       haart:
         init: 0.1
-        prob: 0.1
+        start_haart:
+          1:
+            prob: 0.1
         adherence: 0.1
         discontinue: 0.1
       incar:
@@ -494,7 +508,9 @@ demographics:
         init: 0.1
       haart:
         init: 0.1
-        prob: 0.1
+        start_haart:
+          1:
+            prob: 0.1
         adherence: 0.1
         discontinue: 0.1
       incar:
@@ -558,7 +574,9 @@ demographics:
         init: 0.1
       haart:
         init: 0.1
-        prob: 0.1
+        start_haart:
+          1:
+            prob: 0.1
         adherence: 0.1
         discontinue: 0.1
       incar:
@@ -622,7 +640,9 @@ demographics:
         init: 0.1
       haart:
         init: 0.1
-        prob: 0.1
+        start_haart:
+          1:
+            prob: 0.1
         adherence: 0.1
         discontinue: 0.1
       incar:
@@ -686,7 +706,9 @@ demographics:
         init: 0.1
       haart:
         init: 0.1
-        prob: 0.1
+        start_haart:
+          1:
+            prob: 0.1
         adherence: 0.1
         discontinue: 0.1
       incar:
@@ -743,7 +765,9 @@ demographics:
         init: 0.1
       haart:
         init: 0.1
-        prob: 0.1
+        start_haart:
+          1:
+            prob: 0.1
         adherence: 0.1
         discontinue: 0.1
       incar:

--- a/titan/agent.py
+++ b/titan/agent.py
@@ -73,12 +73,14 @@ class Agent:
         self.hiv = False
         self.hiv_time = 0
         self.hiv_dx = False
+        self.hiv_dx_time = 0
         self.aids = False
 
         # agent treatment params
         self.haart = False
         self.haart_time = 0
         self.haart_adherence = 0
+        self.haart_ever = False
         self.ssp = False
         self.prep = False
         self.prep_adherence = 0

--- a/titan/model.py
+++ b/titan/model.py
@@ -1071,7 +1071,8 @@ class HIVModel:
 
     def diagnose_hiv(self, agent: Agent):
         """
-        Stochastically test the agent for HIV. If tested, mark the agent as diagnosed and trace their partners (if partner tracing enabled).
+        Stochastically test the agent for HIV. If tested, mark the agent as diagnosed
+            and trace their partners (if partner tracing enabled).
 
         args:
             agent: HIV positive agent to diagnose
@@ -1132,6 +1133,8 @@ class HIVModel:
             (HAART).
             HAART was implemented in 1996, hence, there is treatment only after 1996.
             HIV treatment assumes that the agent knows their HIV+ status (`dx` is True).
+            Agent initiation probability depends on time since diagnosis and whether
+            they've previously been on haart.
 
         args:
             agent: agent being updated
@@ -1181,6 +1184,8 @@ class HIVModel:
                         initiate(agent)
                 else:
                     if not agent.haart_ever:
+                        # Look through possible haart probabilities based on time since
+                        # diagnosis
                         for defn in agent.location.params.haart.start_haart:
                             if defn.start_time == agent.hiv_dx_time:
                                 haart_prob = defn.prob
@@ -1191,7 +1196,7 @@ class HIVModel:
                     haart_prob *= self.calibration.haart.coverage
                     if self.run_random.random() < haart_prob:
                         initiate(agent)
-                            
+
             # Go off HAART
             elif agent.haart and self.run_random.random() < haart_params.discontinue:
                 agent.haart = False

--- a/titan/model.py
+++ b/titan/model.py
@@ -1180,12 +1180,18 @@ class HIVModel:
                     ):
                         initiate(agent)
                 else:
-                    haart_prob = haart_params.prob * self.calibration.haart.coverage
-                    for defn in agent.location.params.haart.start_haart:
-                        if defn.start_time == agent.hiv_dx_time:
-                            haart_prob *= defn.prob
+                    if not agent.haart_ever:
+                        for defn in agent.location.params.haart.start_haart:
+                            if defn.start_time == agent.hiv_dx_time:
+                                haart_prob = defn.prob
+                                break
+                    else:
+                        haart_prob = haart_params.reinit_prob
+
+                    haart_prob *= self.calibration.haart.coverage
                     if self.run_random.random() < haart_prob:
                         initiate(agent)
+                            
             # Go off HAART
             elif agent.haart and self.run_random.random() < haart_params.discontinue:
                 agent.haart = False

--- a/titan/model.py
+++ b/titan/model.py
@@ -1187,10 +1187,16 @@ class HIVModel:
                         # Look through possible haart probabilities based on time since
                         # diagnosis
                         for defn in agent.location.params.haart.start_haart:
-                            if defn.start_time == agent.hiv_dx_time:
+                            if (
+                                defn.start_duration
+                                <= agent.hiv_dx_time
+                                < defn.stop_duration
+                            ):
                                 haart_prob = defn.prob
                                 break
-                    else:
+                    if (
+                        not haart_prob
+                    ):  # if no probability found or agent.haart_ever, use reinit prob
                         haart_prob = haart_params.reinit_prob
 
                     haart_prob *= self.calibration.haart.coverage

--- a/titan/params/demographics.yml
+++ b/titan/params/demographics.yml
@@ -70,12 +70,21 @@ demographics:
         type: float
         min: 0.0
         max: 1.0
-      prob:
-        default: 0.0
-        description: "Probability that an agent in this class with HIV becomes enrolled in HAART at a given time step"
-        type: float
-        min: 0.0
-        max: 1.0
+      start_haart:
+        type: definition
+        description: "Probability that an agent in this class with HIV becomes enrolled in HAART at a given time step given how long they've been diagnosed"
+        fields:
+          start_time:
+            type: int
+          prob:
+            type: float
+            min: 0
+            max: 1
+        default:
+          all_time:
+            time_start: -1
+            time_stop: 9999
+            prob: 0.0
       adherence:
         default: 0.0
         description: "Probability that an agent is assigned adherence of 5, otherwise randomly assigned 1-4"

--- a/titan/params/demographics.yml
+++ b/titan/params/demographics.yml
@@ -74,16 +74,19 @@ demographics:
         type: definition
         description: "Probability that an agent in this class with HIV becomes enrolled in HAART at a given time step given how long they've been diagnosed"
         fields:
-          start_time:
+          start_duration:
             type: int
+            min: 0
           prob:
             type: float
             min: 0
             max: 1
+          stop_duration:
+            type: int
+            min: 0
         default:
           all_time:
-            time_start: -1
-            time_stop: 9999
+            start_time: 0
             prob: 0.0
       adherence:
         default: 0.0

--- a/titan/params/demographics.yml
+++ b/titan/params/demographics.yml
@@ -71,23 +71,21 @@ demographics:
         min: 0.0
         max: 1.0
       start_haart:
-        type: definition
-        description: "Probability that an agent in this class with HIV becomes enrolled in HAART at a given time step given how long they've been diagnosed"
+        type: bins
+        description: "Probability that an agent in this class with HIV becomes enrolled in HAART at a given time step given how long they've been diagnosed. Bin keys are starting duration, prob is diagnosis chance during that duration"
         fields:
-          start_duration:
-            type: int
-            min: 0
           prob:
             type: float
-            min: 0
-            max: 1
-          stop_duration:
-            type: int
-            min: 0
+            min: 0.0
+            description: "Probability that agent will start haart if its duration is between this bin's key and the next bin's key"
         default:
-          all_time:
-            start_time: 0
+          1:
             prob: 0.0
+      reinit_prob:
+        type: float
+        description: "Probability that an agent that has previously been on haart will reinitiate"
+        default: 0.0
+        min: 0.0
       adherence:
         default: 0.0
         description: "Probability that an agent is assigned adherence of 5, otherwise randomly assigned 1-4"

--- a/titan/parse_params.py
+++ b/titan/parse_params.py
@@ -177,6 +177,11 @@ def parse_params(defs, params, key_path, pops):
         elif defs["type"] == "definition":
             return get_defn("dummy", defs, key_path, {"dummy": params}, pops)
 
+    try:
+        a = [i for i in defs.items()]
+    except:
+        print(defs)
+        assert False
     for k, v in defs.items():
         # assumes all v are dicts, as otherwise it would have returned
         if "default" in v:


### PR DESCRIPTION
Creates the ability to base haart probability on 1) how long ago the agent was diagnosed and 2) whether the agent has previously been on haart.

Also creating the NYC setting for MSM.