### PR TITLE
Task per process

### DIFF
--- a/run_titan.py
+++ b/run_titan.py
@@ -379,7 +379,7 @@ def main(
     tic = time_mod.time()
     wct = []  # wall clock times
 
-    with Pool(processes=NCORES) as pool:
+    with Pool(processes=NCORES, maxtasksperchild=1) as pool:
         results = [
             pool.apply_async(
                 single_run, (sweep_def, outfile_dir, params, save_pop, pop_path)

--- a/run_titan.py
+++ b/run_titan.py
@@ -379,7 +379,9 @@ def main(
     tic = time_mod.time()
     wct = []  # wall clock times
 
-    with Pool(processes=NCORES, maxtasksperchild=1) as pool:
+    with Pool(
+        processes=NCORES, maxtasksperchild=1
+    ) as pool:  # set max tasks/child to prevent processor drift
         results = [
             pool.apply_async(
                 single_run, (sweep_def, outfile_dir, params, save_pop, pop_path)

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -231,11 +231,13 @@ def test_prep_coverage(make_model_integration, tmpdir):
 
 
 @pytest.mark.integration_stochastic
-def test_syringe_services(make_model_integration, tmpdir):
+def test_syringe_services(params_integration, tmpdir):
     """
     If we use syringe services, does the incidence of hiv decrease?
     """
-    model_a = make_model_integration()
+    params_integration.demographics.black.MSM.drug_type.Inj.init = 1.0
+    params_integration.demographics.black.MSM.drug_type["None"].init = 0.0
+    model_a = HIVModel(params_integration)
 
     path_a = tmpdir.mkdir("a")
     path_a.mkdir("network")


### PR DESCRIPTION
Restricts processing to one task per child. Also corrects PWID population in the syringe services stochastic integration test so it passes more often.