### PR TITLE
fix(atlanta): fix indentation for prep on white msm

### DIFF
--- a/settings/atlanta/demographics.yml
+++ b/settings/atlanta/demographics.yml
@@ -73,9 +73,9 @@ demographics:
         adherence: 0.817
         discontinue: 0.07
       safe_sex: 0.528
-    prep:
-      adherence: 0.911
-      coverage: 0.415
+      prep:
+        adherence: 0.911
+        coverage: 0.415
 
 hiv:
   aids:


### PR DESCRIPTION
Indentation was incorrect for white MSM prep.