### PR TITLE
fix: use prob instead of timeline scaling

### DIFF
--- a/titan/settings/scott/demographics.yml
+++ b/titan/settings/scott/demographics.yml
@@ -49,7 +49,7 @@ demographics:
                   stop: 999
               adherence:
                 init: 1.0
-                prob: 1.0
+                prob: 0.7
               discontinue: 0.000
             death_rate:
               base: 16.6

--- a/titan/settings/scott/model.yml
+++ b/titan/settings/scott/model.yml
@@ -88,26 +88,6 @@ timeline_scaling:
       start_time: -47
       stop_time: 9999
       scalar: 0
-    adh_prob_HF_None:  # make viral suppression probability 0.7 after initial pop creation
-      parameter: demographics|white|sex_type|HF|drug_type|None|haart|adherence
-      start_time: -47
-      stop_time: 9999
-      scalar: 0.7
-    adh_prob_HM_None:   # make viral suppression probability 0.7 after initial pop creation
-      parameter: demographics|white|sex_type|HM|drug_type|None|haart|adherence
-      start_time: -47
-      stop_time: 9999
-      scalar: 0.7
-    adh_prob_HF_Inj:  # make viral suppression probability 0.7 after initial pop creation
-      parameter: demographics|white|sex_type|HF|drug_type|Inj|haart|adherence
-      start_time: -47
-      stop_time: 9999
-      scalar: 0.7
-    adh_prob_HM_Inj:  # make viral suppression probability 0.7 after initial pop creation
-      parameter: demographics|white|sex_type|HM|drug_type|Inj|haart|adherence
-      start_time: -47
-      stop_time: 9999
-      scalar: 0.7
 
 classes:
   sex_types:


### PR DESCRIPTION
I was getting an error when trying to run scott with the timeline scaling (assigning ObjMap to value), seems like the init/prob split in haart demographics handles this now